### PR TITLE
Made the entirety of the image cards clickable in the database page

### DIFF
--- a/pages/database/database.css
+++ b/pages/database/database.css
@@ -97,5 +97,5 @@ body {
 }
 .card__img:hover,
 .card__content:hover {
-  cursor: default;
+  cursor: pointer;
 }

--- a/pages/database/database.html
+++ b/pages/database/database.html
@@ -99,6 +99,7 @@
     <div class="grid">
       <div class="grid__item">
         <div class="card">
+          <a href="./bigfoot/bigfoot.html">
           <img class="card__img" src="bigfoot/bigfoot0.jpeg" />
           <div class="card__content">
             <h1 class="card__header">Bigfoot</h1>
@@ -116,6 +117,7 @@
 
       <div class="grid__item">
         <div class="card">
+          <a href="./mothman/mothman.html">
           <img class="card__img" src="mothman/mothman0.jpeg" />
           <div class="card__content">
             <h1 class="card__header">Mothman</h1>


### PR DESCRIPTION
You can click anywhere on the image card now to go to the respective card's page now instead of just on the button. The mouse cursor was changed to a pointer to reflect this. (Note: I did not remove the old button I just added an additional href property to the encapsulating container)